### PR TITLE
feature/24796 Oculta menu e urls das demais areas do site

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -19,9 +19,10 @@ from django.views.generic.base import RedirectView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', RedirectView.as_view(url='mosaico/')),
-    path('mosaico/', include('mosaico.urls', namespace='mosaico_urls')),
-    path('geologia/', include('geologia.urls', namespace='geologia_urls')),
-    path('contratos/', include('contratos.urls', namespace='contratos_urls')),
+    path('', RedirectView.as_view(url='regionalizacao/')),
+    # Demais urls comentadas aguardando lancamento.
+    # path('mosaico/', include('mosaico.urls', namespace='mosaico_urls')),
+    # path('geologia/', include('geologia.urls', namespace='geologia_urls')),
+    # path('contratos/', include('contratos.urls', namespace='contratos_urls')),
     path('regionalizacao/', include('regionalizacao.urls', namespace='regionalizacao_urls')),
 ]

--- a/global_app/templates/base.html
+++ b/global_app/templates/base.html
@@ -35,19 +35,20 @@
         </a>
         <a href="http://patiodigital.prefeitura.sp.gov.br/livroaberto/"><img src="{% static 'img/logo_livroaberto.svg' %}" alt="Livro Aberto" /></a>
       </div>
-      <a class="menu-toggle" href="#" id="menu-toggle"><img src="{% static 'img/menu.png' %}" alt="Menu" /></a>
+{#      <a class="menu-toggle" href="#" id="menu-toggle"><img src="{% static 'img/menu.png' %}" alt="Menu" /></a>#}
     </div>
   </div>
+{# --- MENU FOI COMENTADO PARA AGUARDAR O LANÇAMENTO DAS DEMAIS AREAS DO SITE  --- #}
 
-  <div class="menu" id="menu">
-    <ul>
-      <li><a href="https://livroaberto.sme.prefeitura.sp.gov.br/">Home</a></li>
-      <li><a href="{% url 'geologia_urls:home' %}">Geologia</a></li>
-      <li><a href="{% url 'mosaico_urls:grupos' %}">Mosaico Orçamentário</a></li>
-      <li><a href="{% url 'contratos_urls:home' %}">Contrato Social</a></li>
-      <li><a href="{% url 'regionalizacao_urls:home' %}">Regionalização</a></li>
-    </ul>
-  </div>
+{#  <div class="menu" id="menu">#}
+{#    <ul>#}
+{#      <li><a href="https://livroaberto.sme.prefeitura.sp.gov.br/">Home</a></li>#}
+{#      <li><a href="{% url 'geologia_urls:home' %}">Geologia</a></li>#}
+{#      <li><a href="{% url 'mosaico_urls:grupos' %}">Mosaico Orçamentário</a></li>#}
+{#      <li><a href="{% url 'contratos_urls:home' %}">Contrato Social</a></li>#}
+{#      <li><a href="{% url 'regionalizacao_urls:home' %}">Regionalização</a></li>#}
+{#    </ul>#}
+{#  </div>#}
 
   <header>
     <div class="wrapper">


### PR DESCRIPTION
Esse PR:

- Oculta menu do site e coloca regionalização como site principal;
- Remove acesso as urls de mosaico, geologia e contrato;